### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -111,7 +111,7 @@ app.post("/login", async (req, res) => {
   console.log(`Login attempt: ${username} with password: ${password}`);
   try {
     const user = await User.findOne({ where: { username } });
-    console.log(`User found:`, user ? `${user.username} with hash: ${user.password}` : 'No user found');
+    console.log(user ? `User found: ${user.username}` : 'No user found');
     
     if (user) {
       const isValidPassword = bcrypt.compareSync(password, user.password);


### PR DESCRIPTION
Potential fix for [https://github.com/thejokers69/fruit-grading/security/code-scanning/2](https://github.com/thejokers69/fruit-grading/security/code-scanning/2)

To fix the issue, we must stop logging the user's password hash during login attempts. Only log necessary, non-sensitive information (such as the username)—never the password (hashed or otherwise), nor other secrets.  
Specifically, update line 114 to remove mention of the user's password hash. The log can simply confirm whether the user exists and include only the username as a reference.  
Code change required: update the logging statement for case when `user` is found, to log only the username (or a similar, non-sensitive identifier).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Prevent clear-text logging of sensitive information by updating the login route to only log the username instead of the user's password hash.

Bug Fixes:
- Remove logging of the user's password hash during login
- Only log non-sensitive user identifier (username) when a user is found